### PR TITLE
chore(go): use go 1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To Be Released
 
+* chore(go): use go 1.17
 * build(deps): bump go.etcd.io/etcd/client/v3 from 3.5.0 to 3.5.4
 * build(deps): bump github.com/iancoleman/strcase from 0.1.1 to 0.2.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-etcd-cron
 
-go 1.16
+go 1.17
 
 require (
 	github.com/iancoleman/strcase v0.2.0


### PR DESCRIPTION
The fix for CVE-2022-29526 is only available in Go 1.17 and 1.18.