### PR TITLE
Add: GetJob, DeleteJob, ListJobsByPrefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ cron.AddJob(Job{
 })
 ```
 
+## Tests
+
+Pre-requisites to run the tests locally:
+- [Install etcd](https://etcd.io/docs/v3.4/install/) 
+- Launch etcd: `etcd --logger=zap`
+- Proceed to run tests: `go test`
+
 ## Release a New Version
 
 Bump new version number in `CHANGELOG.md` and `README.md`.

--- a/cron.go
+++ b/cron.go
@@ -221,7 +221,7 @@ func (c *Cron) Schedule(schedule Schedule, job Job) {
 func (c *Cron) ListJobsByPrefix(prefix string) []*Job {
 	var prefixJobs []*Job
 	for _, entry := range c.entries {
-		if strings.HasPrefix(entry.Job.Name, fmt.Sprintf("%s_", prefix)) {
+		if strings.HasPrefix(entry.Job.Name, prefix) {
 			// Job belongs to the specified prefix
 			prefixJobs = append(prefixJobs, &entry.Job)
 		}
@@ -294,7 +294,8 @@ func (c *Cron) run(ctx context.Context) {
 						ctx = c.funcCtx(ctx, e.Job)
 					}
 
-					m, err := c.etcdclient.NewMutex(fmt.Sprintf("etcd_cron/%s/%d", e.Job.canonicalName(), effective.Unix()))					if err != nil {
+					m, err := c.etcdclient.NewMutex(fmt.Sprintf("etcd_cron/%s/%d", e.Job.canonicalName(), effective.Unix()))
+					if err != nil {
 						go c.etcdErrorsHandler(ctx, e.Job, errors.Wrapf(err, "fail to create etcd mutex for job '%v'", e.Job.Name))
 						return
 					}

--- a/cron.go
+++ b/cron.go
@@ -294,8 +294,7 @@ func (c *Cron) run(ctx context.Context) {
 						ctx = c.funcCtx(ctx, e.Job)
 					}
 
-					m, err := c.etcdclient.NewMutex(fmt.Sprintf("etcd_cron/%s", e.Job.canonicalName()))
-					if err != nil {
+					m, err := c.etcdclient.NewMutex(fmt.Sprintf("etcd_cron/%s/%d", e.Job.canonicalName(), effective.Unix()))					if err != nil {
 						go c.etcdErrorsHandler(ctx, e.Job, errors.Wrapf(err, "fail to create etcd mutex for job '%v'", e.Job.Name))
 						return
 					}

--- a/cron.go
+++ b/cron.go
@@ -3,7 +3,6 @@ package etcdcron
 import (
 	"context"
 	"fmt"
-	"google.golang.org/protobuf/types/known/anypb"
 	"log"
 	"regexp"
 	"runtime/debug"
@@ -43,12 +42,6 @@ type Job struct {
 	Rhythm string
 	// Routine method
 	Func func(context.Context) error
-
-	Repeats  int32
-	DueTime  string
-	TTL      string
-	Data     *anypb.Any
-	Metadata map[string]string
 }
 
 func (j Job) Run(ctx context.Context) error {
@@ -224,15 +217,16 @@ func (c *Cron) Schedule(schedule Schedule, job Job) {
 	c.add <- entry
 }
 
-func (c *Cron) ListJobsByAppID(appID string) []*Job {
-	var appJobs []*Job
+// ListJobsByPrefix returns the list of jobs with the relevant prefix
+func (c *Cron) ListJobsByPrefix(prefix string) []*Job {
+	var prefixJobs []*Job
 	for _, entry := range c.entries {
-		if strings.HasPrefix(entry.Job.Name, fmt.Sprintf("%s_", appID)) {
-			// Job belongs to the specified app_id
-			appJobs = append(appJobs, &entry.Job)
+		if strings.HasPrefix(entry.Job.Name, fmt.Sprintf("%s_", prefix)) {
+			// Job belongs to the specified prefix
+			prefixJobs = append(prefixJobs, &entry.Job)
 		}
 	}
-	return appJobs
+	return prefixJobs
 }
 
 // Entries returns a snapshot of the cron entries.

--- a/cron_test.go
+++ b/cron_test.go
@@ -452,7 +452,7 @@ func TestGetJob(t *testing.T) {
 	}
 
 	select {
-	case <-time.After(15 * time.Second):
+	case <-time.After(ONE_SECOND):
 		t.FailNow()
 	case <-wait(wg):
 	}


### PR DESCRIPTION
I would like to add the rest of the CRUD methods, such that a user can use this pkg to:

- AddJob (already exists)
- GetJob (new)
- DeleteJob (new)
- ListJobsByPrefix (new)

Not sure if there was a reason the `GetJob`, `DeleteJob`, `ListJobsByPrefix` weren't already added?

This PR closes [this issue](https://github.com/Scalingo/go-etcd-cron/issues/78)