### PR TITLE
feat: add new mutex builder constructor to take an existing client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## To Be Released
 
 * build(go): use go 1.24
+* feat: add a NewEtcdMutexBuilderFromClient function to create a mutex builder from an existing etcd client
 
 ## v1.3.3 - Oct. 2 2024
 

--- a/etcd.go
+++ b/etcd.go
@@ -22,6 +22,10 @@ type etcdMutexBuilder struct {
 	*etcdclient.Client
 }
 
+func NewEtcdMutexBuilderFromClient(c *etcdclient.Client) (EtcdMutexBuilder, error) {
+	return etcdMutexBuilder{Client: c}, nil
+}
+
 func NewEtcdMutexBuilder(config etcdclient.Config) (EtcdMutexBuilder, error) {
 	c, err := etcdclient.New(config)
 	if err != nil {
@@ -32,7 +36,7 @@ func NewEtcdMutexBuilder(config etcdclient.Config) (EtcdMutexBuilder, error) {
 
 func (c etcdMutexBuilder) NewMutex(pfx string) (DistributedMutex, error) {
 	// As each task iteration lock name is unique, we don't really care about unlocking it
-	// So the etcd lease will alst 10 minutes, it ensures that even if another server
+	// So the etcd lease will last 10 minutes, it ensures that even if another server
 	// clock is ill-configured (with a maximum span of 10 minutes), it won't execute the task
 	// twice.
 	session, err := concurrency.NewSession(c.Client, concurrency.WithTTL(60*10))


### PR DESCRIPTION
STORY-301

In this PR I am adding a new constructor to build a new EtcdMutexBuilder without passing the config 